### PR TITLE
removing OPEN_API_KEY from benchmark.ipynb

### DIFF
--- a/benchmark.ipynb
+++ b/benchmark.ipynb
@@ -31,11 +31,12 @@
     "import csv\n",
     "import json\n",
     "import itertools\n",
+    "import os\n",
     "from email import message_from_string\n",
     "from langchain.embeddings.openai import OpenAIEmbeddings\n",
     "from langchain.schema import Document\n",
     "from langchain.vectorstores import FAISS\n",
-    "from doctran import Doctran, ExtractProperty"
+    "from doctran import Doctran, ExtractProperty\n"
    ]
   },
   {
@@ -44,7 +45,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "OPENAI_API_KEY = \"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\"\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(\".env\")\n",
+    "OPENAI_API_KEY = os.getenv(\"OPENAI_API_KEY\")\n",
     "OPENAI_MODEL = \"gpt-4\"\n",
     "OPENAI_TOKEN_LIMIT = 8000"
    ]


### PR DESCRIPTION
I came across the benchmark.ipynb notebook while using this package and saw a hard-coded openai key.

Quick change to the notebook to favor an .env file and remove this key for public.