### PR TITLE
FEATURE: adding ability to add system messages 

### DIFF
--- a/doctran/doctran.py
+++ b/doctran/doctran.py
@@ -75,6 +75,7 @@ class Document(BaseModel):
     content_type: ContentType
     raw_content: str
     transformed_content: str
+    system: str
     config: DoctranConfig
     extracted_properties: Optional[Dict] = {}
     metadata: Optional[Dict[str, Any]] = None
@@ -193,7 +194,7 @@ class Doctran:
         if os.environ.get('OPENAI_API_VERSION'):
             self.config.openai.api_version = os.environ['OPENAI_API_VERSION']
 
-    def parse(self, *, content: str, content_type: ContentType = "text", uri: str = None, metadata: dict = None) -> Document:
+    def parse(self, *, content: str,system:str, content_type: ContentType = "text", uri: str = None, metadata: dict = None) -> Document:
         '''
         Parse raw text and apply different chunking schemes based on the content type.
 
@@ -204,5 +205,5 @@ class Doctran:
             uri = str(uuid.uuid4())
         if content_type == ContentType.text.value:
             # TODO: Optional chunking for documents that are too large
-            document = Document(id=str(uuid.uuid4()), content_type=content_type, raw_content=content, transformed_content=content, config=self.config, uri=uri, metadata=metadata)
+            document = Document(id=str(uuid.uuid4()), content_type=content_type, raw_content=content, transformed_content=content,system=system, config=self.config, uri=uri, metadata=metadata)
             return document

--- a/doctran/doctran.py
+++ b/doctran/doctran.py
@@ -75,7 +75,7 @@ class Document(BaseModel):
     content_type: ContentType
     raw_content: str
     transformed_content: str
-    system: str
+    system: Optional[str]
     config: DoctranConfig
     extracted_properties: Optional[Dict] = {}
     metadata: Optional[Dict[str, Any]] = None
@@ -194,7 +194,7 @@ class Doctran:
         if os.environ.get('OPENAI_API_VERSION'):
             self.config.openai.api_version = os.environ['OPENAI_API_VERSION']
 
-    def parse(self, *, content: str,system:str, content_type: ContentType = "text", uri: str = None, metadata: dict = None) -> Document:
+    def parse(self, *, content: str,system: Optional[str] = None, content_type: ContentType = "text", uri: str = None, metadata: dict = None) -> Document:
         '''
         Parse raw text and apply different chunking schemes based on the content type.
 

--- a/doctran/transformers/transformers.py
+++ b/doctran/transformers/transformers.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 import tiktoken
 from doctran import Document, DoctranConfig, ExtractProperty, RecognizerEntity
 
+
 class TooManyTokensException(Exception):
     def __init__(self, content_token_size: int, token_limit: int):
         super().__init__(f"OpenAI document transformation failed. The document is {content_token_size} tokens long, which exceeds the token limit of {token_limit}.")
@@ -59,7 +60,9 @@ class OpenAIDocumentTransformer(DocumentTransformer):
             function_call = OpenAIFunctionCall(
                 seed=self.config.openai_deployment_id,
                 model=self.config.openai_model,
-                messages=[{"role": "user", "content": document.transformed_content}],
+                messages=[{"role": "system", "content":document.system},
+                    
+                    {"role": "user", "content": document.transformed_content}],
                 tools=[{
                     "type": "function",
                     "function": {
@@ -80,7 +83,6 @@ class OpenAIDocumentTransformer(DocumentTransformer):
                                 f"Setting a higher token limit may fix this error. JSON returned: {arguments}")
             first_value = next(iter(arguments.values()))
             if len(arguments) > 1 or not isinstance(first_value, str):
-                # If multiple arguments or a dict/list is returned, treat arguments as extracted values
                 document.extracted_properties = document.extracted_properties or arguments
             else:
                 # If there is only one argument and it's a string, treat arguments as transformed content

--- a/doctran/transformers/transformers.py
+++ b/doctran/transformers/transformers.py
@@ -83,6 +83,7 @@ class OpenAIDocumentTransformer(DocumentTransformer):
                                 f"Setting a higher token limit may fix this error. JSON returned: {arguments}")
             first_value = next(iter(arguments.values()))
             if len(arguments) > 1 or not isinstance(first_value, str):
+                # If multiple arguments or a dict/list is returned, treat arguments as extracted values
                 document.extracted_properties = document.extracted_properties or arguments
             else:
                 # If there is only one argument and it's a string, treat arguments as transformed content

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -2,23 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'openai'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mjson\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mos\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdoctran\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Doctran, ExtractProperty\n",
-      "File \u001b[0;32m~/Desktop/doctran/doctran/__init__.py:1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdoctran\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Doctran, Document, DoctranConfig, ContentType, ExtractProperty, RecognizerEntity, Transformation\n",
-      "File \u001b[0;32m~/Desktop/doctran/doctran/doctran.py:4\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mimportlib\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01myaml\u001b[39;00m\n\u001b[0;32m----> 4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mopenai\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01muuid\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01menum\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Enum\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'openai'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -590,7 +590,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.11.4"
   },
   "orig_nbformat": 4
  },

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -4,7 +4,21 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'openai'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mjson\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mos\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdoctran\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Doctran, ExtractProperty\n",
+      "File \u001b[0;32m~/Desktop/doctran/doctran/__init__.py:1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdoctran\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Doctran, Document, DoctranConfig, ContentType, ExtractProperty, RecognizerEntity, Transformation\n",
+      "File \u001b[0;32m~/Desktop/doctran/doctran/doctran.py:4\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mimportlib\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01myaml\u001b[39;00m\n\u001b[0;32m----> 4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mopenai\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01muuid\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01menum\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Enum\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'openai'"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import os\n",
@@ -590,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.1"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
#  The problem 

Currently there is no way of easily adding system messages other than changing the transformers.py 

# What the PR does 

This PR creates a simple optional way of adding a system message by adding an optional ```system``` field in the Document class, and can be used like this  ```document.parse(content=content, system=system)``` using the parse function. 

# Testing 

The feature has been tested by giving a system message and evaluating the outputs. 
